### PR TITLE
Fix "JSON.stringify cannot serialize cyclic structures" caused by toHaveBeenDispatched

### DIFF
--- a/spec/app/support/dispatcher_matchers.js
+++ b/spec/app/support/dispatcher_matchers.js
@@ -42,7 +42,7 @@ beforeEach(() => {
     toHaveBeenDispatched(){
       return {
         compare(actual){
-          const pass = Dispatcher.dispatch.calls.all().find((dispatchCall) => {
+          const pass = Dispatcher.dispatch.calls.all().some((dispatchCall) => {
             return dispatchCall.args[0].type === actual;
           });
 


### PR DESCRIPTION
Fix toHaveBeenDispatched() to return true/false for "pass"

Previously, it was returning a Jasmine call tracking object,
which caused downstream problems in reporters (particularly,
"JSON.stringify cannot serialize cyclic structures.")

### In-depth:
Running `gulp spec-app` on our react-starter project produced intermittent `JSON.stringify cannot serialize cyclic structures` errors. The errors would often go away if we added, removed, or moved around some tests.

The relevant `JSON.stringify` is in `jasmine-json-stream-reporter` used by `gulp-jasmine-browser`. `jasmine-json-stream-reporter` tries to JSON.stringify every result object, and it was crashing serializing the `passedExpectations` of a Jasmine result object.

`passedExpectations[0].passed`, rather than the boolean one might expect, was a jasmine call tracking object, which PhantomJS + `jasmine-json-stream-reporter` apparently found hard to serialize. If we return a boolean instead, that eliminates at least this cause of the `cyclic structures` error.